### PR TITLE
Improve cleanup commands and more

### DIFF
--- a/org.kde.krename.json
+++ b/org.kde.krename.json
@@ -42,6 +42,9 @@
         {
             "name": "utfcpp",
             "buildsystem": "cmake-ninja",
+            "cleanup": [
+                "/share/utf8cpp"
+            ],
             "sources": [
                 {
                     "type": "archive",
@@ -98,9 +101,7 @@
                 "-DPODOFO_BUILD_STATIC=0"
             ],
             "cleanup": [
-                "/bin",
-                "/share",
-                "/lib/pkgconfig"
+                "/bin"
             ],
             "sources": [
                 {


### PR DESCRIPTION
- Clean up /share/utf8cpp folder to reduce the Flatpak size
- Fix podofo license file is missing error